### PR TITLE
ObjectRepositoryProvider::getRoles() always returns an array of roles.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor
 .DS_Store
 composer.lock
 test/asset/autoload/oauth2.doctrine-orm.global.php
+.idea

--- a/src/Role/ObjectRepositoryProvider.php
+++ b/src/Role/ObjectRepositoryProvider.php
@@ -75,8 +75,8 @@ class ObjectRepositoryProvider
                 // left to right so reverse the array
                 $roles[] = new Role\Role($role->getRoleId(), array_reverse($parents));
             }
-
-            return $roles;
         }
+
+        return $roles;
     }
 }


### PR DESCRIPTION
The ObjectRepositoryProvider must always return an array of roles